### PR TITLE
Improve Linux browser launcher detection in auth flow

### DIFF
--- a/zaim_client/auth.py
+++ b/zaim_client/auth.py
@@ -8,6 +8,9 @@ import os
 import json
 import time
 import secrets
+import shutil
+import subprocess
+import sys
 import webbrowser
 import urllib.parse
 from pathlib import Path
@@ -204,11 +207,40 @@ class ZaimAuthManager:
     
     def open_browser(self, url: str) -> bool:
         """ブラウザでURLを開く"""
+        if sys.platform.startswith('linux'):
+            launchers = [
+                'xdg-open',
+                'wslview',
+                'sensible-browser',
+                'gnome-open',
+                'kde-open5',
+                'kde-open',
+            ]
+
+            for launcher in launchers:
+                launcher_path = shutil.which(launcher)
+                if not launcher_path:
+                    continue
+
+                try:
+                    subprocess.run(
+                        [launcher_path, url],
+                        check=True,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                    return True
+                except (subprocess.CalledProcessError, OSError):
+                    continue
+
         try:
-            webbrowser.open(url)
-            return True
+            opened = webbrowser.open(url, new=2)
+            if opened:
+                return True
         except Exception:
-            return False
+            pass
+
+        return False
     
     def login(self, port: Optional[int] = None, print_url: bool = False, timeout: int = 300) -> bool:
         """


### PR DESCRIPTION
## Summary
- detect common Linux browser launchers with `shutil.which` and invoke them via `subprocess.run`
- fall back to `webbrowser.open` and only report failure when every launcher attempt fails

## Testing
- python - <<'PY'
    from zaim_client.auth import ZaimAuthManager

    manager = ZaimAuthManager('key', 'secret')
    result = manager.open_browser('https://example.com')
    print('open_browser result:', result)
    PY

------
https://chatgpt.com/codex/tasks/task_e_68d7c9fcf498832f87c980bccae40880